### PR TITLE
Fix selecting text on mobile

### DIFF
--- a/src/components/LyricViewer.vue
+++ b/src/components/LyricViewer.vue
@@ -58,8 +58,8 @@ export default defineComponent({
 }
 
 .lyrics {
-  user-select: text !important;
-  -webkit-user-select: text !important;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .lyrics.georgian {

--- a/src/components/LyricViewer.vue
+++ b/src/components/LyricViewer.vue
@@ -57,6 +57,11 @@ export default defineComponent({
   line-height: 1.6;
 }
 
+.lyrics {
+  user-select: text !important;
+  -webkit-user-select: text !important;
+}
+
 .lyrics.georgian {
   font-family: 'Noto Sans Georgian', sans-serif;
 }


### PR DESCRIPTION
This change is called to fix problem that bugs me on my phone: not being able to select text of the song. 

Tested locally on my iphone in Chrome browser — this change fixes the bug. 

Demonstration (with the fix):

<img src="https://github.com/user-attachments/assets/311db7ca-0a18-46d1-b5b7-e2af12a6c8f1" alt="Giorgobistve" width="200">
